### PR TITLE
fix: query reverted to query instead of undefined url

### DIFF
--- a/src/sources/spotify.js
+++ b/src/sources/spotify.js
@@ -152,7 +152,7 @@ async function search(query) {
 
 async function loadFrom(query, type) {
   if (!globalThis.NodeLinkSources.Spotify) {
-    debugLog('loadtracks', 4, { type: 3, sourceName: 'Spotify', query: url, message: 'Spotify source is not available.' })
+    debugLog('loadtracks', 4, { type: 3, sourceName: 'Spotify', query, message: 'Spotify source is not available.' })
 
     return {
       loadType: 'error',


### PR DESCRIPTION
## Changes

Changed undefined variable url to query to prevent NodeLink from displaying unwanted errors in console

## Why 

It fixes the unwanted error.

## Checkmarks

- [X] The modified endpoints have been tested.
- [X] Used the same indentation as the rest of the project.
- [X] Still compatible with LavaLink clients.

## Additional information

